### PR TITLE
Add contributor type to .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,11 +18,13 @@
   ],
   "contributors": [
     {
+      "type":"Other",
       "affiliation": "Earth Lab, University of Colorado - Boulder",
       "name": "Herwehe, Lauren",
       "orcid": "0000-0002-8841-8879"
     },
     {
+      "type":"Other",
       "affiliation": "DigitalGlobe",
       "name": "Morrissey, Martha"
     }


### PR DESCRIPTION
This PR adds the contributor type as Other to .zenodo.json for a new release. 